### PR TITLE
Add support for custom command prefix

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,15 +4,18 @@ import ListenerManager from "./listener/listenerManager";
 import CommandParserModule, { ArgTypes } from "./command/commandParser";
 interface CookiecordOptions {
 	botAdmins?: string[];
-	commandArgumentTypes?: ArgTypes
+	commandArgumentTypes?: ArgTypes;
+	commandPrefix?: string
 }
 export default class CookiecordClient extends Client {
 	public commandManager: CommandManager;
 	public listenerManager: ListenerManager;
 	public botAdmins: string[];
+	public commandPrefix: string;
 	constructor(opts: CookiecordOptions = {}, discordOpts: ClientOptions = {}) { // look at the example lol wait!!! 
 		super(discordOpts);
 		this.botAdmins = opts.botAdmins || []; 
+		this.commandPrefix = opts.commandPrefix || 'cc!';
 		this.commandManager = new CommandManager();
 		this.listenerManager = new ListenerManager(this);
 		new CommandParserModule(this, opts.commandArgumentTypes || {});

--- a/src/command/commandParser.ts
+++ b/src/command/commandParser.ts
@@ -36,7 +36,7 @@ export default class CommandParserModule extends Module {
     }
     @listener({ event: "message" })
     onMessage(msg: Message) {
-        const prefix = "cc!";
+        const prefix = this.client.commandPrefix;
         if (msg.author && msg.author.bot) return;
         if (!msg.content.startsWith(prefix)) return;
         const noPrefix = msg.content.replace(prefix, "");


### PR DESCRIPTION
This PR allows developers to use a different prefix for their bot, instead of only "cc!"