### PR TITLE
Add support for forwarding references when initialising modules

### DIFF
--- a/example/factory.ts
+++ b/example/factory.ts
@@ -1,0 +1,7 @@
+import { default as CookiecordClient } from "../src";
+
+import ReferencedModule from "./modules/referenced";
+
+new CookiecordClient()
+    .registerModuleFromFactory(c => new ReferencedModule(c, 30))
+    .login(process.env.TOKEN);

--- a/example/factory.ts
+++ b/example/factory.ts
@@ -3,5 +3,5 @@ import { default as CookiecordClient } from "../src";
 import ReferencedModule from "./modules/referenced";
 
 new CookiecordClient()
-    .registerModuleFromFactory(c => new ReferencedModule(c, 30))
+    .registerModuleFromFactory((c) => new ReferencedModule(c, 30))
     .login(process.env.TOKEN);

--- a/example/instance.ts
+++ b/example/instance.ts
@@ -1,0 +1,7 @@
+import { default as CookiecordClient } from "../src";
+
+import ReferencedModule from "./modules/referenced";
+
+const c = new CookiecordClient();
+c.registerModuleInstance(new ReferencedModule(c, 60));
+c.login(process.env.TOKEN);

--- a/example/modules/referenced.ts
+++ b/example/modules/referenced.ts
@@ -1,0 +1,12 @@
+import { Message } from "discord.js";
+import { default as CookiecordClient, listener, Module } from "../../src";
+
+export default class ReferencedModule extends Module {
+    constructor(client: CookiecordClient, public readonly data: number) {
+        super(client);
+    }
+    @listener({ event: "ready" })
+    onMessage(msg: Message) {
+        console.log("referencedModule ready", this.data);
+    }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,34 +69,23 @@ class CookiecordClient extends Client {
                     module.constructor.name})`
             );
         const mod = module instanceof Module ? module : new module(this);
-        mod.processListeners
-            .bind(mod)()
-            .forEach(l => this.listenerManager.add(l));
-        mod.processCommands
-            .bind(mod)()
-            .forEach(c => this.commandManager.add(c));
-        this.modules.add(mod);
+        this.registerModuleInstance(mod);
         return this;
     }
 
-    registerModuleInstance(instance: typeof Module) {
+    registerModuleInstance(instance: Module) {
         if (!(instance instanceof Module))
             throw new TypeError(
                 "registerModuleFromInstance only takes in instances of Module"
             );
-
         if (
             Array.from(this.modules).some(
-                m =>
-                    m.constructor.name == instance.name ||
-                    m.constructor.name == instance.constructor.name
+                m => m.constructor.name == instance.constructor.name
             )
         )
             throw new Error(
-                `cannot register multiple modules with same name (${instance.name ||
-                    instance.constructor.name})`
+                `cannot register multiple modules with same name (${instance.constructor.name})`
             );
-
         instance.processListeners
             .bind(instance)()
             .forEach(l => this.listenerManager.add(l));
@@ -104,6 +93,15 @@ class CookiecordClient extends Client {
             .bind(instance)()
             .forEach(c => this.commandManager.add(c));
         this.modules.add(instance);
+        return this;
+    }
+
+    registerModuleFromFactory(factory: (client: CookiecordClient) => Module) {
+        if (typeof factory !== "function")
+            throw new TypeError(
+                "registerModuleFactory only takes in a factory that returns a Module instance"
+            );
+        this.registerModuleInstance(factory(this));
         return this;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -97,10 +97,6 @@ class CookiecordClient extends Client {
     }
 
     registerModuleFromFactory(factory: (client: CookiecordClient) => Module) {
-        if (typeof factory !== "function")
-            throw new TypeError(
-                "registerModuleFromFactory only takes in a factory that returns a Module instance"
-            );
         this.registerModuleInstance(factory(this));
         return this;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,7 +76,7 @@ class CookiecordClient extends Client {
     registerModuleInstance(instance: Module) {
         if (!(instance instanceof Module))
             throw new TypeError(
-                "registerModuleFromInstance only takes in instances of Module"
+                "registerModuleInstance only takes in instances of Module"
             );
         if (
             Array.from(this.modules).some(
@@ -99,7 +99,7 @@ class CookiecordClient extends Client {
     registerModuleFromFactory(factory: (client: CookiecordClient) => Module) {
         if (typeof factory !== "function")
             throw new TypeError(
-                "registerModuleFactory only takes in a factory that returns a Module instance"
+                "registerModuleFromFactory only takes in a factory that returns a Module instance"
             );
         this.registerModuleInstance(factory(this));
         return this;

--- a/src/client.ts
+++ b/src/client.ts
@@ -59,7 +59,7 @@ class CookiecordClient extends Client {
             );
         if (
             Array.from(this.modules).some(
-                m =>
+                (m) =>
                     m.constructor.name == module.name ||
                     m.constructor.name == module.constructor.name
             )
@@ -80,7 +80,7 @@ class CookiecordClient extends Client {
             );
         if (
             Array.from(this.modules).some(
-                m => m.constructor.name == instance.constructor.name
+                (m) => m.constructor.name == instance.constructor.name
             )
         )
             throw new Error(
@@ -88,10 +88,10 @@ class CookiecordClient extends Client {
             );
         instance.processListeners
             .bind(instance)()
-            .forEach(l => this.listenerManager.add(l));
+            .forEach((l) => this.listenerManager.add(l));
         instance.processCommands
             .bind(instance)()
-            .forEach(c => this.commandManager.add(c));
+            .forEach((c) => this.commandManager.add(c));
         this.modules.add(instance);
         return this;
     }
@@ -109,11 +109,11 @@ class CookiecordClient extends Client {
         if (!this.modules.has(mod))
             throw new Error("Cannot unregister unregistered module");
         Array.from(this.listenerManager.listeners)
-            .filter(l => l.module == mod)
-            .forEach(l => this.listenerManager.remove(l));
+            .filter((l) => l.module == mod)
+            .forEach((l) => this.listenerManager.remove(l));
         Array.from(this.commandManager.cmds)
-            .filter(c => c.module == mod)
-            .forEach(c => this.commandManager.remove(c));
+            .filter((c) => c.module == mod)
+            .forEach((c) => this.commandManager.remove(c));
         this.modules.delete(mod);
         return this;
     }
@@ -122,7 +122,7 @@ class CookiecordClient extends Client {
         const fn = join(process.cwd(), path);
         const watcher = chokidar.watch(fn);
 
-        watcher.on("change", file => {
+        watcher.on("change", (file) => {
             // Here be dragons.
             // Might need more validation here...
             delete require.cache[file];
@@ -132,7 +132,7 @@ class CookiecordClient extends Client {
             if (module.default) {
                 if (Object.getPrototypeOf(module.default) == Module) {
                     const old = Array.from(this.modules).find(
-                        mod => module.default.name == mod.constructor.name
+                        (mod) => module.default.name == mod.constructor.name
                     );
                     if (old) this.unregisterModule(old);
                     this.registerModule(module.default);
@@ -150,7 +150,7 @@ class CookiecordClient extends Client {
 
     loadModulesFromFolder(path: string) {
         const files = readdirSync(path);
-        files.forEach(file => {
+        files.forEach((file) => {
             const fn = join(process.cwd(), path, file);
             const module = require(fn);
             if (module.default) {


### PR DESCRIPTION
This fixes issue #11 by providing two additional public methods on CookiecordClient which allows end-users to add modules by instance or factory.

![image](https://user-images.githubusercontent.com/12851394/101260403-86d09180-3727-11eb-9cce-86d49daf210c.png)

