### PR TITLE
Add `once` flag to listener options

### DIFF
--- a/example/modules/example.ts
+++ b/example/modules/example.ts
@@ -52,6 +52,11 @@ export default class ExampleModule extends Module {
         msg.channel.send(this.client.guilds.cache.size + offset);
     }
 
+    @listener({ event: "ready", once: true })
+    onceReady() {
+        console.log("onceReady");
+    }
+
     @listener({ event: "message" })
     onMessage(msg: Message) {
         console.log("onMessage", msg.content);

--- a/src/listener/decorator.ts
+++ b/src/listener/decorator.ts
@@ -3,12 +3,14 @@ import { Event } from "../util/clientEvents";
 
 export interface IListenerDecoratorOptions {
     event: Event;
+    once?: boolean;
 }
-export interface IListenerDecoratorMeta {
-    event: Event;
+interface IListenerDecoratorMeta {
     id: string;
     func: Function;
 }
+
+export type IListenerDecorator = IListenerDecoratorOptions & IListenerDecoratorMeta;
 
 export default function listener(opts: IListenerDecoratorOptions) {
     return function (
@@ -26,11 +28,12 @@ export default function listener(opts: IListenerDecoratorOptions) {
                 `Decorator needs to be applied to a Method. (${targetConstructorName}#${descriptor.value.name} was ${descriptor.value.constructor.name})`
             );
 
-        const listenersMeta: IListenerDecoratorMeta[] =
+        const listenersMeta: IListenerDecorator[] =
             Reflect.getMetadata("cookiecord:listenerMetas", target) || [];
 
         listenersMeta.push({
             event: opts.event,
+            once: opts.once || false,
             id: propertyKey,
             func: Reflect.get(target, propertyKey)
         });

--- a/src/listener/listener.ts
+++ b/src/listener/listener.ts
@@ -3,6 +3,7 @@ import { Module } from "..";
 
 export default interface Listener {
     event: Event;
+    once: boolean;
     id: string;
     module: Module;
     func: Function;

--- a/src/listener/listenerManager.ts
+++ b/src/listener/listenerManager.ts
@@ -19,7 +19,9 @@ export default class ListenerManager {
         listener.wrapperFunc = (...args: any[]) =>
             listener.func.apply(listener.module, args);
         this.listeners.add(listener);
-        this.client.on(listener.event, listener.wrapperFunc);
+        listener.once
+            ? this.client.once(listener.event, listener.wrapperFunc)
+            : this.client.on(listener.event, listener.wrapperFunc);
     }
 
     remove(listener: Listener) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import CookiecordClient from "./client";
 import { ICommandDecorator } from "./command/decorator";
-import { IListenerDecoratorMeta } from "./listener/decorator";
+import { IListenerDecorator } from "./listener/decorator";
 import { getArgTypes } from "./util/argTypeProvider";
 import { Command, Listener } from ".";
 
@@ -11,13 +11,14 @@ export default class Module {
         this.client = client;
     }
     processListeners() {
-        const listenersMeta: IListenerDecoratorMeta[] =
+        const listenersMeta: IListenerDecorator[] =
             Reflect.getMetadata("cookiecord:listenerMetas", this) || [];
 
         return listenersMeta.map(
             (meta) =>
                 ({
                     event: meta.event,
+                    once: meta.once,
                     id: this.constructor.name + "/" + meta.id,
                     module: this,
                     func: meta.func


### PR DESCRIPTION
This PR adds a flag to listener options that allows for the listener to only trigger once upon events.
An example use-case is a `onceReady` listener that starts an interval for cycling through different activity strings.