### PR TITLE
Add `exactArgs` flag to command options

### DIFF
--- a/example/modules/example.ts
+++ b/example/modules/example.ts
@@ -75,6 +75,10 @@ export default class ExampleModule extends Module {
     single(msg: Message, str: string) {
         msg.channel.send("You said " + str);
     }
+    @command({ exactArgs: true })
+    exact(msg: Message, word: string) {
+        msg.channel.send("Exact word: " + word);
+    }
     @command()
     badboy(msg: Message, m: GuildMember) {
         msg.channel.send(`${m} is a bad boy!`);

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -10,6 +10,7 @@ export default interface Command {
     description?: string;
     module: Module;
     single: boolean;
+    exactArgs: boolean;
     inhibitors: Inhibitor[];
     usesContextAPI: boolean;
     onError: (msg: Message, error: Error) => void;

--- a/src/command/commandParser.ts
+++ b/src/command/commandParser.ts
@@ -38,11 +38,11 @@ export default class CommandParserModule extends Module {
         }
         // Argument type validation
         const typedArgs = [] as unknown[];
-        const leastArgs =
-            cmd.args.length - cmd.args.filter((x) => x.optional).length;
         if (cmd.single) {
             typedArgs.push(stringArgs.join(" "));
         } else {
+            const leastArgs =
+                cmd.args.length - cmd.args.filter(x => x.optional).length;
             if (stringArgs.length < leastArgs) {
                 return msg.reply(
                     `:warning: expected at least ${leastArgs} argument${

--- a/src/command/commandParser.ts
+++ b/src/command/commandParser.ts
@@ -43,7 +43,7 @@ export default class CommandParserModule extends Module {
         if (cmd.single) {
             typedArgs.push(stringArgs.join(" "));
         } else {
-            if (stringArgs.length < leastArgs)
+            if (stringArgs.length < leastArgs) {
                 return msg.reply(
                     `:warning: expected at least ${leastArgs} argument${
                         leastArgs !== 1 ? "s" : ""
@@ -51,6 +51,15 @@ export default class CommandParserModule extends Module {
                         stringArgs.length !== 1 ? "s" : ""
                     } instead`
                 );
+            } else if (cmd.exactArgs && stringArgs.length > cmd.args.length) {
+                return msg.reply(
+                    `:warning: expected at most ${cmd.args.length} argument${
+                        cmd.args.length !== 1 ? "s" : ""
+                    } but got ${stringArgs.length} argument${
+                        stringArgs.length !== 1 ? "s" : ""
+                    } instead`
+                );
+            }
             for (const i in stringArgs) {
                 if (!cmd.args[i]) continue; // avoid null
                 const sa = stringArgs[i];

--- a/src/command/decorator.ts
+++ b/src/command/decorator.ts
@@ -7,6 +7,7 @@ export interface ICommandDecoratorOptions {
     description?: string;
     aliases: string[];
     single: boolean;
+    exactArgs: boolean;
     inhibitors: Inhibitor[];
     onError: (msg: Message, error: Error) => void;
 }
@@ -70,6 +71,7 @@ export function command(
                 optional: optionals.includes(i + 1)
             })),
             single: opts.single || false,
+            exactArgs: opts.exactArgs || false,
             inhibitors: opts.inhibitors || [],
             usesContextAPI: types[0] == Context,
             onError:

--- a/src/module.ts
+++ b/src/module.ts
@@ -40,6 +40,7 @@ export default class Module {
                     ),
                     module: this,
                     single: meta.single,
+                    exactArgs: meta.exactArgs,
                     inhibitors: meta.inhibitors,
                     onError: meta.onError,
                     usesContextAPI: meta.usesContextAPI


### PR DESCRIPTION
Fixes #22. 

This currently has the flag set to `false` by default, but I can imagine that we'd want it to be `true` instead. Thoughts?