### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/example/modules/example.ts
+++ b/example/modules/example.ts
@@ -87,7 +87,7 @@ export default class ExampleModule extends Module {
     }
     @command({})
     todo(msg: Message) {
-        msg.channel.send("```" + readFileSync("../TODO").toString().substr(0, 1900) + "```");
+        msg.channel.send("```" + readFileSync("../TODO").toString().slice(0, 1900) + "```");
     }
     @command({
         inhibitors: [


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.